### PR TITLE
Chore: Change line endings from LF to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,17 @@
-*.lua text eol=crlf linguist-language=Lua working-tree-encoding=cp932
+* text=auto
+
 *.obj text eol=crlf linguist-language=Lua working-tree-encoding=cp932
 *.anm text eol=crlf linguist-language=Lua working-tree-encoding=cp932
 *.scn text eol=crlf linguist-language=Lua working-tree-encoding=cp932
 *.cam text eol=crlf linguist-language=Lua working-tree-encoding=cp932
 *.tra text eol=crlf linguist-language=Lua working-tree-encoding=cp932
+
+*.obj2 text eol=crlf linguist-language=Lua working-tree-encoding=utf-8
 *.anm2 text eol=crlf linguist-language=Lua working-tree-encoding=utf-8
-*.hlsl text eol=crlf linguist-language=hlsl working-tree-encoding=utf-8
-*.h text eol=crlf linguist-language=C working-tree-encoding=utf-8
-*.c text eol=crlf linguist-language=C working-tree-encoding=utf-8
-*.hpp text eol=crlf linguist-language=C++ working-tree-encoding=utf-8
-*.cpp text eol=crlf linguist-language=C++ working-tree-encoding=utf-8
-*.json text eol=crlf linguist-language=json working-tree-encoding=utf-8
-*.py text eol=crlf linguist-language=Python working-tree-encoding=utf-8
+*.scn2 text eol=crlf linguist-language=Lua working-tree-encoding=utf-8
+*.cam2 text eol=crlf linguist-language=Lua working-tree-encoding=utf-8
+*.tra2 text eol=crlf linguist-language=Lua working-tree-encoding=utf-8
+
+*.jpg binary
+*.png binary
+*.gif binary

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AviUtl ExEdit2のカメラ操作感を変更するスクリプト群．
 
 ### 導入
 
-1.  同梱の`*.cam2`と`.*dll`を`%ProgramData%`内の`aviutl2\\Script`フォルダまたはその子フォルダに入れる．
+1.  同梱の`*.cam2`と`*.dll`を`%ProgramData%`内の`aviutl2\\Script`フォルダまたはその子フォルダに入れる．
 
 `beta4`以降では`aviutl2.exe`と同じ階層内の`data\\Script`フォルダ内でも可．
 
@@ -173,6 +173,9 @@ AviUtl ExEdit2のカメラ操作感を変更するスクリプト群．
 LICENSEファイルに記載．
 
 ## Change Log
+
+- **v1.0.1**
+  - 改行コードをCRLFに変更．
 
 - **v1.0.0**
   - Release

--- a/dll_src/CMakeLists.txt
+++ b/dll_src/CMakeLists.txt
@@ -1,14 +1,5 @@
 cmake_minimum_required(VERSION 3.20.0)
-project(CameraTransform_K VERSION 1.0.0 LANGUAGES CXX)
-
-# Set the project version.
-set(PROJECT_VERSION_SUFFIX "" CACHE STRING "Version suffix (e.g., alpha, beta, rc, etc.)")
-
-if(PROJECT_VERSION_SUFFIX)
-    set(FULL_VERSION "${PROJECT_VERSION} - ${PROJECT_VERSION_SUFFIX}")
-else()
-    set(FULL_VERSION "${PROJECT_VERSION}")
-endif()
+project(CameraTransform_K VERSION 1.0.1 LANGUAGES CXX)
 
 # Main target definition.
 add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
This update modifies the .gitattributes file to change line endings from LF to CRLF, matching the standard used in AviUtl's official scripts.